### PR TITLE
Key event fix

### DIFF
--- a/LayoutSwitcher/AppDelegate.swift
+++ b/LayoutSwitcher/AppDelegate.swift
@@ -178,10 +178,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Enable key event monitor
         editEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            
+            // reset Flag when any key is pressed to prevent unwanted layout switch
+            // e.g. when user selects a text with [shift + option + arrow keys] combination
+            self.modifiersPressed = false
+            let char = event.charactersIgnoringModifiers
+            let charCode = event.keyCode
             if (event.modifierFlags.contains(.control)){
-                let char = event.charactersIgnoringModifiers
-                let charCode = event.keyCode;
+                
                 if(self.enabledEditKeysValues.contains(char ?? "/")){
                     self.sendDefaultEditHotkey(char ?? "/", code:charCode)
                 }

--- a/LayoutSwitcher/AppDelegate.swift
+++ b/LayoutSwitcher/AppDelegate.swift
@@ -13,7 +13,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private var enabledEditKeysValues: [String] = []
     private var editKeysState: EditHotKeys = []
-    
+    private var modifiersPressed = false
+
     private struct Constants {
         // Launcher application bundle identifier
         static let helperBundleID = "com.triton.layoutswitcherlauncher"
@@ -156,9 +157,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Enable key event monitor
         langEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { event in
-            if (event.modifierFlags.contains(.shift) &&
-                event.modifierFlags.contains(secondModifierFlag)) {
-                    self.sendDefaultChangeLayoutHotkey()
+            let areModifiersActive = event.modifierFlags.contains(.shift) && event.modifierFlags.contains(secondModifierFlag)
+            if areModifiersActive {
+                // set Flag when required modifier keys pressed
+                self.modifiersPressed = true
+            } else if self.modifiersPressed {
+                // if required modifier keys pressed and Flag is set
+                // run change layout routine (keys released)
+                self.sendDefaultChangeLayoutHotkey()
+                // reset Flag
+                self.modifiersPressed = false
             }
         }
     }


### PR DESCRIPTION
Fix for two issues:
1. It's reasonable when layout switches only after modifier keys are released (not like current behaviour when user just press them)
2. It's also reasonable to avoid false triggering when user presses modifier keys with some extra keys. e.g. when they select text using combination like [option + shift + arrow keys]. If users set [option + shift] as the  layout change combination they don't expect  [option + shift + arrow keys] will also change the layout.